### PR TITLE
Implement patching for Affinity.CloudServices to block analytics to api.canva.com

### DIFF
--- a/AffinityPatcher/Program.cs
+++ b/AffinityPatcher/Program.cs
@@ -263,6 +263,12 @@ namespace AffinityPatcher
                             Patcher.PatchWithLdcRetVerbose(method.FullName, method.Body, 0, verbose);
                             patchedList.Add(method.FullName);
                         }
+                        // For other return types, do not patch but log when verbose is enabled
+                        else if (verbose)
+                        {
+                            AnsiConsole.MarkupLine(
+                                $"[yellow]Skipping method '{method.FullName}' with unsupported return type '{method.ReturnType.FullName}' (not void/bool).[/]");
+                        }
                     }
                 }
                 

--- a/AffinityPatcher/Program.cs
+++ b/AffinityPatcher/Program.cs
@@ -76,7 +76,7 @@ namespace AffinityPatcher
             }
             else
             {
-                AnsiConsole.MarkupLine("[red]Warning: Serif.Interop.Persona.dll not found. Main patches skipped.[/]");
+                AnsiConsole.MarkupLine("[yellow]Warning: Serif.Interop.Persona.dll not found. Main patches skipped.[/]");
             }
 
             // Patch CloudServices (fix for Issue #11)

--- a/AffinityPatcher/Utils/Patcher.cs
+++ b/AffinityPatcher/Utils/Patcher.cs
@@ -22,4 +22,18 @@ public static class Patcher
 
         PatchWithLdcRet(cilBody, ldcValue);
     }
+    public static void PatchWithRet(CilBody cilBody)
+    {
+        cilBody.Instructions.Clear();
+        cilBody.ExceptionHandlers.Clear();
+        cilBody.Variables.Clear();
+        cilBody.Instructions.Add(Instruction.Create(OpCodes.Ret));
+    }
+
+    public static void PatchWithRetVerbose(string methodFullName, CilBody cilBody, bool verbose = false)
+    {
+        if (verbose)
+            AnsiConsole.MarkupLine($"Located [grey]{methodFullName}[/], patching with [grey]\"return;\" (void)[/].");
+        PatchWithRet(cilBody);
+    }
 }


### PR DESCRIPTION
This pull request enhances the Affinity patching process by introducing targeted analytics-blocking patches for the `Affinity.CloudServices.dll` assembly, in addition to improving feedback and flexibility when required assemblies are missing. The changes also add new utility methods to streamline patching methods that return `void`.

**Affinity patching improvements:**

* The patching process now attempts to patch both `Serif.Interop.Persona.dll` (the main assembly) and, if present, `Affinity.CloudServices.dll` to block analytics-related functionality. If `Affinity.CloudServices.dll` is not found, a warning is displayed and the process continues, providing better compatibility with different Affinity versions.
* Added a new method, `PatchCloudServicesAssembly`, which scans for analytics/telemetry-related types and methods in `Affinity.CloudServices.dll`, and neutralizes methods that send, track, or initialize analytics data by replacing their bodies with immediate returns.

**Patcher utility enhancements:**

* Introduced `PatchWithRet` and `PatchWithRetVerbose` utility methods in `Patcher.cs` to simplify replacing method bodies with a single `ret` instruction for methods that return `void`, with optional verbose logging for improved traceability.